### PR TITLE
Fixes an error when a password contains a '%'.

### DIFF
--- a/getmail/Dockerfiles/getmail_imap2lmtp.py
+++ b/getmail/Dockerfiles/getmail_imap2lmtp.py
@@ -288,7 +288,7 @@ def get_configparser_file():
     return
 
   logging.info("use config file: %s" % config_file_path)
-  configparser_file = configparser.ConfigParser()
+  configparser_file = configparser.ConfigParser(interpolation=None)
   configparser_file.read([os.path.abspath(config_file_path)])
 
   return configparser_file


### PR DESCRIPTION
Disables interpolation in configparser.

https://stackoverflow.com/questions/14340366/configparser-and-string-with/28874886
nterpolation